### PR TITLE
make: Make dtb.img depend on the DTB directory itself

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -843,8 +843,8 @@ $(call dist-for-goals, sdk win_sdk sdk_addon, $(INSTALLED_FILES_FILE_ROOT))
 ifdef BOARD_INCLUDE_DTB_IN_BOOTIMG
 INSTALLED_DTBIMAGE_TARGET := $(PRODUCT_OUT)/dtb.img
 ifdef BOARD_PREBUILT_DTBIMAGE_DIR
-$(INSTALLED_DTBIMAGE_TARGET) : $(sort $(wildcard $(BOARD_PREBUILT_DTBIMAGE_DIR)/*.dtb))
-	cat $^ > $@
+$(INSTALLED_DTBIMAGE_TARGET): $(BOARD_PREBUILT_DTBIMAGE_DIR)
+	cat $(shell find $(BOARD_PREBUILT_DTBIMAGE_DIR) -type f -name "*.dtb" | sort) > $@
 endif
 endif
 


### PR DESCRIPTION
We shouldn't be depending on .dtb files for this, because if the directory
doesn't exist for some reason, the DTBs just won't get added to the image.
Instead depend on the directory itself.

Also, the current cat command generates static rules with a list of DTBs
that it finds when build rules are generated. This isn't good, especially
when we build our own DTBs, so rewrite it to find DTBs at "command running
time" instead.

Change-Id: Ia9336e9767999bc792aa977a73ae9739a4bc2c37